### PR TITLE
Add support for Google Pay

### DIFF
--- a/android/src/main/java/ca/zyra/capacitor/stripe/GooglePayHelper.kt
+++ b/android/src/main/java/ca/zyra/capacitor/stripe/GooglePayHelper.kt
@@ -3,14 +3,12 @@ package ca.zyra.capacitor.stripe
 import android.content.Context
 import com.getcapacitor.JSArray
 import com.getcapacitor.JSObject
-import com.google.android.gms.wallet.IsReadyToPayRequest
-import com.google.android.gms.wallet.PaymentsClient
-import com.google.android.gms.wallet.Wallet
-import com.google.android.gms.wallet.WalletConstants
+import com.google.android.gms.wallet.*
 import com.stripe.android.GooglePayConfig
-import org.json.JSONObject
+import org.json.JSONArray
+import java.lang.IllegalArgumentException
 
-internal fun GetGooglePayEnv(isTest: Boolean): Int {
+internal fun getGooglePayEnv(isTest: Boolean): Int {
     return if (isTest) {
         WalletConstants.ENVIRONMENT_TEST
     } else {
@@ -18,7 +16,7 @@ internal fun GetGooglePayEnv(isTest: Boolean): Int {
     }
 }
 
-internal fun GooglePayPaymentsClient(context: Context, env: Int): PaymentsClient {
+internal fun googlePayPaymentsClient(context: Context, env: Int): PaymentsClient {
     return Wallet.getPaymentsClient(
             context,
             Wallet.WalletOptions.Builder()
@@ -27,101 +25,59 @@ internal fun GooglePayPaymentsClient(context: Context, env: Int): PaymentsClient
     )
 }
 
-internal fun GooglePayDummyRequest(): IsReadyToPayRequest {
-    val allowedAuthMethods = JSArray()
-    allowedAuthMethods.put("PAN_ONLY")
-    allowedAuthMethods.put("CRYPTOGRAM_3DS")
+internal fun googlePayDefaultCardPaymentMethod(): JSObject {
+    return JSObject()
+            .put("type", "CARD")
+            .put(
+                    "parameters",
+                    JSObject()
+                            .put("allowedAuthMethods", JSONArray()
+                                    .put("PAN_ONLY")
+                                    .put("CRYPTOGRAM_3DS"))
+                            .put("allowedCardNetworks",
+                                    JSArray()
+                                            .put("AMEX")
+                                            .put("DISCOVER")
+                                            .put("JCB")
+                                            .put("MASTERCARD")
+                                            .put("VISA"))
+                            .put("billingAddressRequired", false)
+            )
+}
 
-    val allowedCardNetworks = JSArray()
-    allowedCardNetworks.put("AMEX")
-    allowedCardNetworks.put("DISCOVER")
-    allowedCardNetworks.put("JCB")
-    allowedCardNetworks.put("MASTERCARD")
-    allowedCardNetworks.put("VISA")
+internal fun googlePayReadyRequest(allowedPaymentMethods: JSArray? = null): IsReadyToPayRequest {
+    val pms = allowedPaymentMethods ?: JSArray().put(googlePayDefaultCardPaymentMethod())
 
     val isReadyToPayRequestJson = JSObject()
-    isReadyToPayRequestJson.putOpt("allowedAuthMethods", allowedAuthMethods)
-    isReadyToPayRequestJson.putOpt("allowedCardNetworks", allowedCardNetworks)
+    isReadyToPayRequestJson.put("apiVersion", 2)
+    isReadyToPayRequestJson.put("apiVersionMinor", 0)
+    isReadyToPayRequestJson.put("allowedPaymentMethods", pms)
 
     return IsReadyToPayRequest.fromJson(isReadyToPayRequestJson.toString())
 }
 
-internal fun GooglePayCardParams(opts: JSObject): JSONObject {
-    val authMethods = opts.getJSONArray("allowedAuthMethods")
-    val cardNetworks = opts.getJSONArray("allowedCardNetworks")
-    val allowPrepaidCards = opts.getBoolean("allowPrepaidCards", true)
-    val billingAddressRequired = opts.getBoolean("billingAddressRequired", false)
-    val billingAddressParams = opts.getJSObject("billingAddressParameters", JSObject())
-
-    return JSObject()
-            .putOpt("allowedAuthMethods", authMethods)
-            .putOpt("allowedCardNetworks", cardNetworks)
-            .putOpt("allowPrepaidCards", allowPrepaidCards)
-            .putOpt("billingAddressRequired", billingAddressRequired)
-            .putOpt("billingAddressParameters", billingAddressParams)
-}
-
-internal fun GooglePayTxInfo(opts: JSObject): JSONObject {
-    val currencyCode = opts.getString("currencyCode")
-    val countryCode = opts.getString("countryCode")
-    val transactionId = opts.getString("transactionId")
-    val totalPriceStatus = opts.getString("totalPriceStatus")
-    val totalPrice = opts.getString("totalPrice")
-    val totalPriceLabel = opts.getString("totalPriceLabel")
-    val checkoutOption = opts.getString("checkoutOption")
-
-    return JSObject()
-            .putOpt("currencyCode", currencyCode)
-            .putOpt("countryCode", countryCode)
-            .putOpt("transactionId", transactionId)
-            .putOpt("totalPriceStatus", totalPriceStatus)
-            .putOpt("totalPrice", totalPrice)
-            .putOpt("totalPriceLabel", totalPriceLabel)
-            .putOpt("checkoutOption", checkoutOption)
-}
-
-internal fun GooglePayCardPaymentMethod(publishableKey: String, opts: JSObject): JSONObject {
-    val params = GooglePayCardParams(opts)
-    val tokenizationSpec = GooglePayConfig(publishableKey).tokenizationSpecification
-
-    return JSObject()
-            .putOpt("type", "CARD")
-            .putOpt("parameters", params)
-            .putOpt("tokenizationSpecification", tokenizationSpec)
-}
-
-internal fun GooglePayDataReq(publishableKey: String, opts: JSObject): String {
-    val txInfo = GooglePayTxInfo(opts)
-    val emailRequired = opts.getBoolean("emailRequired", false)
-    val merchantName = opts.getString("merchantName")
-    val cardPaymentMethod = GooglePayCardPaymentMethod(publishableKey, opts)
-
-    val req = JSObject()
-            .putOpt("apiVersion", 2)
-            .putOpt("apiVersionMinor", 0)
-            .putOpt("allowedPaymentMethods", JSArray().put(cardPaymentMethod))
-            .putOpt("transactionInfo", txInfo)
-            .putOpt("emailRequired", emailRequired)
-
-    if (merchantName != null && merchantName.isNotEmpty()) {
-        req.putOpt(
-                "merchantInfo",
-                JSObject().putOpt("merchantName", merchantName)
-        )
+internal fun googlePayDataRequest(publishableKey: String, paymentDataRequest: JSObject): PaymentDataRequest {
+    if (!paymentDataRequest.has("transactionInfo")) {
+        throw IllegalArgumentException("paymentDataRequest must contain transactionInfo")
+    }
+    if (!paymentDataRequest.has("merchantInfo")) {
+        throw IllegalArgumentException("paymentDataRequest must contain merchantInfo")
     }
 
-    val shippingAddressRequired = opts.getBoolean("shippingAddressRequired", false)
+    paymentDataRequest
+            .put("apiVersion", 2)
+            .put("apiVersionMinor", 0)
 
-    if (shippingAddressRequired!!) {
-        val shippingAddressParams = opts.getJSObject(
-                "shippingAddressParameters",
-                JSObject()
-        )
-
-        req
-                .putOpt("shippingAddressRequired", true)
-                .putOpt("shippingAddressParameters", shippingAddressParams)
+    if (!paymentDataRequest.has("allowedPaymentMethods")) {
+        val tokenizationSpec = GooglePayConfig(publishableKey).tokenizationSpecification
+        val cardPaymentMethod = googlePayDefaultCardPaymentMethod()
+                .put("tokenizationSpecification", tokenizationSpec)
+        paymentDataRequest.put("allowedPaymentMethods",
+                        JSONArray().put(cardPaymentMethod))
+    }
+    if (!paymentDataRequest.has("emailRequired")) {
+        paymentDataRequest.put("emailRequired", false)
     }
 
-    return req.toString()
+    return PaymentDataRequest.fromJson(paymentDataRequest.toString())
 }

--- a/android/src/main/java/ca/zyra/capacitor/stripe/StripePlugin.kt
+++ b/android/src/main/java/ca/zyra/capacitor/stripe/StripePlugin.kt
@@ -1,15 +1,24 @@
 package ca.zyra.capacitor.stripe
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.util.Log
 import androidx.activity.ComponentActivity
 import com.getcapacitor.*
+import com.google.android.gms.wallet.AutoResolveHelper
+import com.google.android.gms.wallet.PaymentData
+import com.google.android.gms.wallet.PaymentsClient
 import com.stripe.android.*
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.view.BillingAddressFields
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import org.json.JSONObject
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.suspendCoroutine
 import com.stripe.android.Stripe as StripeInstance
 
 
@@ -30,6 +39,14 @@ class Stripe : Plugin(), EphemeralKeyProvider, PaymentSession.PaymentSessionList
     private var paymentSessionDidChangeCallback: PluginCall? = null
 
     private var requestPaymentCallback: PluginCall? = null
+
+    private var totalAmount = 0L
+
+    private var googlePaymentsClient: PaymentsClient? = null
+    private var googlePayAvailable: Boolean? = null
+    private var googlePayContinuation: Continuation<ActivityResult>? = null
+
+    private data class ActivityResult(val resultCode: Int, val data: Intent?)
 
     private var paymentConfig = PaymentConfig()
     private data class PaymentConfig(
@@ -74,7 +91,7 @@ class Stripe : Plugin(), EphemeralKeyProvider, PaymentSession.PaymentSessionList
         }
     }
 
-    private fun resetCustomerContext(context: Context): CustomerSession? {
+    private suspend fun resetCustomerContext(context: Context): CustomerSession? {
         Log.i(TAG, "resetCustomerContext")
 
         PaymentConfiguration.init(context, publishableKey)
@@ -82,6 +99,13 @@ class Stripe : Plugin(), EphemeralKeyProvider, PaymentSession.PaymentSessionList
         CustomerSession.endCustomerSession()
         CustomerSession.initCustomerSession(context, this, true)
         customerSession = CustomerSession.getInstance()
+
+        val client = googlePayPaymentsClient(context, getGooglePayEnv(isTest))
+        googlePaymentsClient = client
+        val isReadyToPayRequest = waitForTask(client.isReadyToPay(googlePayReadyRequest()))
+        googlePayAvailable = isReadyToPayRequest.isSuccessful
+
+        totalAmount = 0
 
         return customerSession
     }
@@ -214,14 +238,17 @@ class Stripe : Plugin(), EphemeralKeyProvider, PaymentSession.PaymentSessionList
                 }
 
                 if (paymentSession == null) {
+                    val config = paymentConfig.copy(
+                            googlePayEnabled = paymentConfig.googlePayEnabled && (googlePayAvailable ?: false)
+                    )
                     val result =
-                        PaymentSession(activity as ComponentActivity, paymentConfig.config())
+                        PaymentSession(activity as ComponentActivity, config.config())
                     result.init(this@Stripe)
                     paymentSession = result
                 }
 
                 val amount = call.data.optLong("amount", 0L)
-
+                totalAmount = amount
                 paymentSession?.setCartTotal(amount)
             } catch (e: Exception) {
                 call.error("Unable to update payment context: ${e.localizedMessage}", e)
@@ -299,16 +326,56 @@ class Stripe : Plugin(), EphemeralKeyProvider, PaymentSession.PaymentSessionList
                 Log.i(TAG, "requestPayment")
 
                 requestPaymentCallback = call
-                val paymentMethod = currentPaymentSessionData?.paymentMethod ?: throw Exception("No currentPaymentSessionData paymentMethod")
+
+                val paymentSessionData = currentPaymentSessionData ?: throw Exception("No currentPaymentSessionData")
+                val paymentMethod = if (paymentSessionData.useGooglePay) {
+                    payWithGoogle()
+                } else {
+                    paymentSessionData.paymentMethod ?: throw Exception("No currentPaymentSessionData paymentMethod")
+                }
 
                 paymentSessionCreatedPaymentResultCallback?.let {
                     val result = JSObject()
-                    result.put("paymentMethod", pmToJson(paymentMethod))
+                    result.put("paymentMethod", paymentMethod?.let { pm -> pmToJson(pm) })
                     it.success(result)
                 }
             } catch (e: Exception) {
                 call.error("Unable to request payment: ${e.localizedMessage}", e)
             }
+        }
+    }
+
+    private suspend fun payWithGoogle(): PaymentMethod? {
+        val client = googlePaymentsClient ?: throw Exception("No googlePaymentsClient")
+        val totalPrice = "${totalAmount / 100}.${totalAmount % 100}"
+        val request = JSObject()
+                .put("transactionInfo", JSObject()
+                        .put("totalPrice", totalPrice)
+                        .put("totalPriceStatus", "FINAL")
+                        .put("currencyCode", "USD"))
+                .put("merchantInfo", JSObject()
+                        .put("merchantName", paymentConfig.companyName))
+        val activityResult = suspendCoroutine<ActivityResult> { cont ->
+            googlePayContinuation = cont
+            AutoResolveHelper.resolveTask(
+                    client.loadPaymentData(googlePayDataRequest(publishableKey, request)),
+                    activity,
+                    LOAD_PAYMENT_DATA_REQUEST_CODE
+            )
+        }
+        return when (activityResult.resultCode) {
+            Activity.RESULT_OK -> {
+                val paymentData = activityResult.data?.let { PaymentData.getFromIntent(it) }
+                        ?: throw Exception("Unable to get payment data from Google Pay result")
+                val paymentMethodCreateParams = PaymentMethodCreateParams.createFromGooglePay(JSONObject(paymentData.toJson()))
+                return waitForStripe { cb -> stripeInstance.createPaymentMethod(paymentMethodCreateParams, callback = cb) }
+            }
+            Activity.RESULT_CANCELED -> null
+            AutoResolveHelper.RESULT_ERROR -> {
+                val status = AutoResolveHelper.getStatusFromIntent(activityResult.data)
+                throw Exception("Error invoking Google Pay: $status")
+            }
+            else -> throw Exception("Unexpected result from Google Pay")
         }
     }
 
@@ -340,10 +407,15 @@ class Stripe : Plugin(), EphemeralKeyProvider, PaymentSession.PaymentSessionList
 
                 val result = JSObject()
                 currentPaymentSessionData?.let {
-                    val name = it.paymentMethod?.card?.brand?.displayName
-                    val last4 = it.paymentMethod?.card?.last4
+                    val label = if (it.useGooglePay) {
+                        "Google Pay"
+                    } else {
+                        val name = it.paymentMethod?.card?.brand?.displayName ?: ""
+                        val last4 = it.paymentMethod?.card?.last4 ?: ""
+                        "$name $last4"
+                    }
 
-                    result.put("label", (name ?: "") + " " + (last4 ?: ""))
+                    result.put("label", label)
 
                     // The icon resource is: it.paymentMethod?.card?.brand?.icon but we don't have a way to load this into the same format (a data url) as iOS.
                 }
@@ -380,6 +452,8 @@ class Stripe : Plugin(), EphemeralKeyProvider, PaymentSession.PaymentSessionList
                 CustomerSession.endCustomerSession()
                 customerSession = null
                 paymentSession = null
+                googlePaymentsClient = null
+                googlePayAvailable = null
 
                 call.success()
             } catch (e: Exception) {
@@ -423,7 +497,11 @@ class Stripe : Plugin(), EphemeralKeyProvider, PaymentSession.PaymentSessionList
     }
 
     override fun handleOnActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        super.handleOnActivityResult(requestCode, resultCode, data)
-        paymentSession?.handlePaymentData(requestCode, resultCode, data)
+        if (requestCode == LOAD_PAYMENT_DATA_REQUEST_CODE) {
+            googlePayContinuation?.resumeWith(Result.success(ActivityResult(resultCode, data)))
+        } else {
+            super.handleOnActivityResult(requestCode, resultCode, data)
+            paymentSession?.handlePaymentData(requestCode, resultCode, data)
+        }
     }
 }

--- a/android/src/main/java/ca/zyra/capacitor/stripe/WrappedPaymentSessionData.kt
+++ b/android/src/main/java/ca/zyra/capacitor/stripe/WrappedPaymentSessionData.kt
@@ -1,0 +1,12 @@
+package ca.zyra.capacitor.stripe
+
+import com.stripe.android.PaymentSessionData
+
+/* A little wrapper around Stripe's PaymentSessionData class, since we cannot construct one of
+ * those, so we can have a separate field tracking whether the user wants to use google pay,
+ * since the Stripe library does not remember that for us (the way it remembers a selected card).
+ */
+class WrappedPaymentSessionData(
+        val useGooglePay: Boolean,
+        val paymentSessionData: PaymentSessionData
+)


### PR DESCRIPTION
To use this, an app must add `<meta-data android:name="com.google.android.gms.wallet.api.enabled" android:value="true" />` to the `<application>` in its manifest.

The only API change is that the paymentSessionCreatedPaymentResultCallback might now be called with a `null` payment method if a user backs out at the GPay UI. (It didn't seem right to treat this as an error.)